### PR TITLE
ACF block builder added via composer. Test TwoColumn block created.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
     "roots/wp-config": "1.0.0",
     "roots/wp-password-bcrypt": "1.1.0",
     "wpackagist-theme/twentytwentythree": "^1.0",
-    "roots/acorn": "^2.1"
+    "roots/acorn": "^2.1",
+    "log1x/acf-composer": "^2.1"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.7.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dbe06164a1e6dbe824a3390b5d55e985",
+    "content-hash": "4f1213073c9a1ab7d71b91f497096658",
     "packages": [
         {
             "name": "brick/math",
@@ -1381,6 +1381,66 @@
             "time": "2022-04-17T13:12:02+00:00"
         },
         {
+            "name": "log1x/acf-composer",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Log1x/acf-composer.git",
+                "reference": "71e2695277c4f96bb62bc59e158ee5a4a4754be6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Log1x/acf-composer/zipball/71e2695277c4f96bb62bc59e158ee5a4a4754be6",
+                "reference": "71e2695277c4f96bb62bc59e158ee5a4a4754be6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3|^8.0",
+                "stoutlogic/acf-builder": "^1.11"
+            },
+            "require-dev": {
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "suggest": {
+                "log1x/modern-acf-options": "Gives ACF option pages a much needed design overhaul."
+            },
+            "type": "package",
+            "extra": {
+                "acorn": {
+                    "providers": [
+                        "Log1x\\AcfComposer\\Providers\\AcfComposerServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Log1x\\AcfComposer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brandon Nifong",
+                    "email": "brandon@tendency.me"
+                }
+            ],
+            "description": "Create fields, blocks, option pages, and widgets using ACF Builder and Sage 10",
+            "support": {
+                "issues": "https://github.com/Log1x/acf-composer/issues",
+                "source": "https://github.com/Log1x/acf-composer/tree/v2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Log1x",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-10-14T18:37:36+00:00"
+        },
+        {
             "name": "monolog/monolog",
             "version": "2.8.0",
             "source": {
@@ -2661,6 +2721,52 @@
                 }
             ],
             "time": "2021-10-31T01:18:58+00:00"
+        },
+        {
+            "name": "stoutlogic/acf-builder",
+            "version": "v1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/StoutLogic/acf-builder.git",
+                "reference": "e63ab87233ea3675cd519f1dd6b6d4230b3cef97"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/StoutLogic/acf-builder/zipball/e63ab87233ea3675cd519f1dd6b6d4230b3cef97",
+                "reference": "e63ab87233ea3675cd519f1dd6b6d4230b3cef97",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "^1.1|^2.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpdocumentor/reflection-docblock": "2.*",
+                "phpunit/phpunit": "4.*",
+                "squizlabs/php_codesniffer": "^2.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "StoutLogic\\AcfBuilder\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Steve Pfisterer",
+                    "email": "steve@stoutlogic.com"
+                }
+            ],
+            "description": "An Advanced Custom Field Configuration Builder",
+            "support": {
+                "issues": "https://github.com/StoutLogic/acf-builder/issues",
+                "source": "https://github.com/StoutLogic/acf-builder/tree/v1.12.0"
+            },
+            "time": "2021-09-17T17:32:44+00:00"
         },
         {
             "name": "symfony/console",

--- a/web/app/themes/sage/app/Blocks/TwoColumn.php
+++ b/web/app/themes/sage/app/Blocks/TwoColumn.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace App\Blocks;
+
+use Log1x\AcfComposer\Block;
+use StoutLogic\AcfBuilder\FieldsBuilder;
+
+class TwoColumn extends Block
+{
+    /**
+     * The block name.
+     *
+     * @var string
+     */
+    public $name = 'Two Column';
+
+    /**
+     * The block description.
+     *
+     * @var string
+     */
+    public $description = 'A simple Two Column block.';
+
+    /**
+     * The block category.
+     *
+     * @var string
+     */
+    public $category = 'formatting';
+
+    /**
+     * The block icon.
+     *
+     * @var string|array
+     */
+    public $icon = 'editor-ul';
+
+    /**
+     * The block keywords.
+     *
+     * @var array
+     */
+    public $keywords = [];
+
+    /**
+     * The block post type allow list.
+     *
+     * @var array
+     */
+    public $post_types = [];
+
+    /**
+     * The parent block type allow list.
+     *
+     * @var array
+     */
+    public $parent = [];
+
+    /**
+     * The default block mode.
+     *
+     * @var string
+     */
+    public $mode = 'preview';
+
+    /**
+     * The default block alignment.
+     *
+     * @var string
+     */
+    public $align = '';
+
+    /**
+     * The default block text alignment.
+     *
+     * @var string
+     */
+    public $align_text = '';
+
+    /**
+     * The default block content alignment.
+     *
+     * @var string
+     */
+    public $align_content = '';
+
+    /**
+     * The supported block features.
+     *
+     * @var array
+     */
+    public $supports = [
+        'align' => true,
+        'align_text' => false,
+        'align_content' => false,
+        'full_height' => false,
+        'anchor' => false,
+        'mode' => false,
+        'multiple' => true,
+        'jsx' => true,
+    ];
+
+    /**
+     * The block styles.
+     *
+     * @var array
+     */
+    public $styles = [
+        [
+            'name' => 'light',
+            'label' => 'Light',
+            'isDefault' => true,
+        ],
+        [
+            'name' => 'dark',
+            'label' => 'Dark',
+        ]
+    ];
+
+    /**
+     * The block preview example data.
+     *
+     * @var array
+     */
+    public $example = [
+        'items' => [
+            ['item' => 'Item one'],
+            ['item' => 'Item two'],
+            ['item' => 'Item three'],
+        ],
+    ];
+
+    /**
+     * Data to be passed to the block before rendering.
+     *
+     * @return array
+     */
+    public function with()
+    {
+        return [
+            'items' => $this->items(),
+        ];
+    }
+
+    /**
+     * The block field group.
+     *
+     * @return array
+     */
+    public function fields()
+    {
+        $twoColumn = new FieldsBuilder('two_column');
+
+        $twoColumn
+            ->addRepeater('items')
+                ->addText('item')
+            ->endRepeater();
+
+        return $twoColumn->build();
+    }
+
+    /**
+     * Return the items field.
+     *
+     * @return array
+     */
+    public function items()
+    {
+        return get_field('items') ?: $this->example['items'];
+    }
+
+    /**
+     * Assets to be enqueued when rendering the block.
+     *
+     * @return void
+     */
+    public function enqueue()
+    {
+        //
+    }
+}

--- a/web/app/themes/sage/config/acf.php
+++ b/web/app/themes/sage/config/acf.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Field Type Settings
+    |--------------------------------------------------------------------------
+    |
+    | Here you can set default field group and field type configuration that
+    | is then merged with your field groups when they are composed.
+    |
+    | This allows you to avoid the repetitive process of setting common field
+    | configuration such as `ui` on every `trueFalse` field or your
+    | preferred `instruction_placement` on every `fieldGroup`.
+    |
+    */
+
+    'defaults' => [
+        'trueFalse' => ['ui' => 1],
+        'select' => ['ui' => 1],
+    ],
+];

--- a/web/app/themes/sage/resources/views/blocks/two-column.blade.php
+++ b/web/app/themes/sage/resources/views/blocks/two-column.blade.php
@@ -1,0 +1,15 @@
+<div class="{{ $block->classes }}">
+  @if ($items)
+    <ul>
+      @foreach ($items as $item)
+        <li>{{ $item['item'] }}</li>
+      @endforeach
+    </ul>
+  @else
+    <p>{{ $block->preview ? 'Add an item...' : 'No items found!' }}</p>
+  @endif
+
+  <div>
+    <InnerBlocks />
+  </div>
+</div>


### PR DESCRIPTION
Add acf block builder with example two column block (not populated) 

Instal failed on first attempt following https://github.com/Log1x/acf-composer guide. 

Correct method was to run the composer install command, then run `wp acorn optimize:clear`, then the `wp acorn vendor:publish --provider="Log1x\AcfComposer\Providers\AcfComposerServiceProvider"`

