### PR TITLE
Added padding L and R to gutenberg editor wrapper. Had to use !import…

### DIFF
--- a/web/app/themes/sage/resources/styles/editor.scss
+++ b/web/app/themes/sage/resources/styles/editor.scss
@@ -1,0 +1,12 @@
+.editor-styles-wrapper {
+    padding-left: 2rem !important;
+    padding-right: 2rem !important;
+  
+    .block-editor-block-list__block {
+      margin: 0 auto;
+      padding: 1rem 0;
+    }
+  }
+  
+//   .wp-block {
+//   }


### PR DESCRIPTION
…ant to force changes.

@Nelboh this is a dirty fix but it works and makes it visually nicer to use. Guess this can be a quick fix for now until we know more. 