### PR TITLE
Amends/oct2

### DIFF
--- a/site/web/app/themes/sage/app/Blocks/CtaBanner.php
+++ b/site/web/app/themes/sage/app/Blocks/CtaBanner.php
@@ -134,6 +134,7 @@ class CtaBanner extends Block
         'title_style' => ['title' => 'CTA - variation full', 'heading_level' => 'h2', 'heading_style' => 'h2'],
         'body' => 'Body text - Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dolor eius in explicabo!',
         'image' => ['url' => 'https://placehold.co/800x800', 'alt' => 'alt text'], 'image_position' => 'left','show_button' => 'yes',
+        'image_width' => '50',
         'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' => 'primary', 'btn_colour' => '', 'new_tab' => ''],
     ];
 
@@ -150,6 +151,7 @@ class CtaBanner extends Block
             'body' => get_field('body'),
             'image' => get_field('image'),
             'image_position' => get_field('image_position'),
+            'image_width' => get_field('image_width'),
             'show_button' => get_field('show_button'),
             'cta_button' => get_field('cta_button'),
             'layout' => get_field('layout'),
@@ -203,6 +205,18 @@ class CtaBanner extends Block
                 'default_value' => 'left',
                 'layout' => 'horizontal',
             ])->conditional('add_image', '==', 'yes')
+            ->addSelect('image_width', [
+                'label' => 'Image Width',
+                'instructions' => 'Choose the width of the image %.',
+                'required' => 0,
+                'choices' => [
+                    '50' => '50',
+                    '40' => '40',
+                ],
+                'default_value' => '50',
+                'layout' => 'horizontal',
+            ])->conditional('add_image', '==', 'yes')
+
 
             ->addTab('Layout')->conditional('add_image', '==', 'no')
             ->addSelect('layout', [

--- a/site/web/app/themes/sage/app/Blocks/CtaBanner.php
+++ b/site/web/app/themes/sage/app/Blocks/CtaBanner.php
@@ -127,14 +127,14 @@ class CtaBanner extends Block
      * @var array
      */
     public $example = [
-        'layout' => 'full', 
-        'background_colour' => 'raspberry', 
-        'wrapper' => '', 
-        'spacing_size' => '', 
+        'layout' => 'full',
+        'background_colour' => 'raspberry',
+        'wrapper' => '',
+        'spacing_size' => '',
         'title_style' => ['title' => 'CTA - variation full', 'heading_level' => 'h2', 'heading_style' => 'h2'],
-        'body' => 'Body text - Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dolor eius in explicabo!', 
+        'body' => 'Body text - Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dolor eius in explicabo!',
         'image' => ['url' => 'https://placehold.co/800x800', 'alt' => 'alt text'], 'image_position' => 'left','show_button' => 'yes',
-        'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' => 'primary', 'btn_colour' => '']
+        'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' => 'primary', 'btn_colour' => '', 'new_tab' => ''],
     ];
 
     /**

--- a/site/web/app/themes/sage/app/Blocks/CustomGrid.php
+++ b/site/web/app/themes/sage/app/Blocks/CustomGrid.php
@@ -158,7 +158,8 @@ class CustomGrid extends Block
         'btn_type' => '',
         'btn_link' => '',
         'btn_text' => '',
-        'btn_colour' => ''
+        'btn_colour' => '',
+        'new_tab' => ''
     ];
 
     /**

--- a/site/web/app/themes/sage/app/Blocks/Form.php
+++ b/site/web/app/themes/sage/app/Blocks/Form.php
@@ -179,7 +179,8 @@ class Form extends Block
                 'instructions' => 'Choose form option.',
                 'choices' => [
                     'newsletter' => 'Newsletter',
-                    'other' => 'Other'
+                    'other' => 'Other',
+                    'contact' => 'Contact'
                 ]
             ])
             ->addText('form_shortcode', [

--- a/site/web/app/themes/sage/app/Blocks/HeroFrontPage.php
+++ b/site/web/app/themes/sage/app/Blocks/HeroFrontPage.php
@@ -139,7 +139,7 @@ class HeroFrontPage extends Block
         ],
         'hero_content' => '<p>Hero subtitle - Lorem ipsum dolor sit amet: consectetur sadipscing. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum.Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum. Lorem ipsum dolor sit amet consectetur adipisicing elit.</p><p>Quisquam, voluptatum. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum. Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>',
         'show_button' => 'yes',
-        'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' => 'primary', 'btn_colour' => '']
+        'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' => 'primary', 'btn_colour' => '', 'new_tab' => ''],
     ];
 
     /**

--- a/site/web/app/themes/sage/app/Fields/Partials/Button.php
+++ b/site/web/app/themes/sage/app/Fields/Partials/Button.php
@@ -37,6 +37,11 @@ class Button extends Partial
                 'instructions' => 'Enter the link for the button.',
                 'required' => 1,
                 'default_value' => '/',
+            ])->conditional('type', '!=', 'donate')
+            ->addTrueFalse('new_tab', [
+                'label' => 'Open in new tab?',
+                'instructions' => 'Check this box to open the link in a new tab.',
+                'default_value' => 0,
             ])->conditional('type', '!=', 'donate');
 
         return $button;

--- a/site/web/app/themes/sage/resources/styles/scss/blocks/_cta-banner.scss
+++ b/site/web/app/themes/sage/resources/styles/scss/blocks/_cta-banner.scss
@@ -66,7 +66,7 @@
     object-position: center center;
 
     // media query for landscape orientation
-    @media screen and (orientation: landscape) 
+    @media screen and (orientation: landscape)
     and (max-width: 900px) {
       max-height: 80vh;
     }
@@ -103,6 +103,18 @@
       &__body {
         width: 50%;
         padding-left: rem(74);
+      }
+    }
+  }
+
+  &.width--40 {
+    @include media-breakpoint('lg') {
+      img {
+        width: 40%;
+      }
+
+      .cta-banner__image__content__body {
+        width: 60%;
       }
     }
   }

--- a/site/web/app/themes/sage/resources/styles/scss/blocks/_form.scss
+++ b/site/web/app/themes/sage/resources/styles/scss/blocks/_form.scss
@@ -129,25 +129,13 @@
         }
     }
 
-    // TODO: Delete this code
-    #mc_embed_signup_scroll {
-        h2 {
-            display: none;
-        }
+    &.contact {
+      height: 1215px;
     }
 
     input[type='submit'] {
         @extend .button;
         @extend .button--primary;
-    }
-
-    // TODO: Delete this code
-    input {
-        border-bottom-width: 4px !important;
-
-        &::placeholder {
-            text-transform: uppercase !important;
-        }
     }
 
     input:not([type='submit']) {
@@ -169,7 +157,7 @@
             align-items: center;
             gap: 0.5rem;
         }
-        
+
         input[type='checkbox'] {
             width: fit-content;
             margin-right: 0.5rem;

--- a/site/web/app/themes/sage/resources/styles/scss/partials/_card.scss
+++ b/site/web/app/themes/sage/resources/styles/scss/partials/_card.scss
@@ -82,7 +82,7 @@
   &__content {
     position: absolute;
     left: 0;
-    top: $spacing--xs;
+    bottom: $spacing--xs;
     margin: $spacing--sm;
     z-index: 1;
   }
@@ -99,29 +99,6 @@
       line-height: 1.5;
       -webkit-box-decoration-break: clone;
       box-decoration-break: clone;
-    }
-  }
-
-  @include media-breakpoint('md') {
-    &:nth-child(odd) {
-      .card__content {
-        top: $spacing--xs;
-
-        @include media-breakpoint('lg') {
-          top: $spacing--sm;
-        }
-      }
-    }
-
-    &:nth-child(even) {
-      .card__content {
-        bottom: $spacing--xs;
-        top: unset;
-
-        @include media-breakpoint('lg') {
-          bottom: $spacing--sm;
-        }
-      }
     }
   }
 

--- a/site/web/app/themes/sage/resources/styles/scss/sections/_footer.scss
+++ b/site/web/app/themes/sage/resources/styles/scss/sections/_footer.scss
@@ -149,7 +149,7 @@
         background-repeat: no-repeat;
         background-position: bottom;
         background-size: cover;
-        
+
         @include media-breakpoint(md) {
             background-repeat: repeat-x;
             background-size: contain;
@@ -276,7 +276,7 @@
     position: fixed;
     visibility: hidden;
     z-index: 899;
-    bottom: 4rem;
+    bottom: 5rem;
     right: 1rem;
     width: 60px;
     height: 60px;

--- a/site/web/app/themes/sage/resources/views/404.blade.php
+++ b/site/web/app/themes/sage/resources/views/404.blade.php
@@ -4,7 +4,7 @@
   {{-- @include('partials.page-header') --}}
 
   @if (! have_posts())
-    
+
       <div class="error-404 full-bleed block-padding">
         <div class="error-404__circle">
           <p class="h1">404</p>

--- a/site/web/app/themes/sage/resources/views/blocks/button-block.blade.php
+++ b/site/web/app/themes/sage/resources/views/blocks/button-block.blade.php
@@ -5,6 +5,7 @@
             'link' => $btn_link,
             'text' => $btn_text,
             'colour' => $btn_colour,
+            'new_tab' => $btn_new_tab,
         ])
     </div>
 </section>

--- a/site/web/app/themes/sage/resources/views/blocks/card-row.blade.php
+++ b/site/web/app/themes/sage/resources/views/blocks/card-row.blade.php
@@ -33,6 +33,7 @@
                               'link' => $item['link'],
                               'text' => $item['text'],
                               'colour' => $item['btn_colour'],
+                              'new_tab' => $item['new_tab'],
                               ])
                           @endif
                         </div>

--- a/site/web/app/themes/sage/resources/views/blocks/cta-banner.blade.php
+++ b/site/web/app/themes/sage/resources/views/blocks/cta-banner.blade.php
@@ -65,6 +65,7 @@
                         'link' => $btn_link,
                         'text' => $btn_text,
                         'colour' => $button_colour,
+                        'new_tab' => $btn_new_tab,
                     ])
                 @endif
 

--- a/site/web/app/themes/sage/resources/views/blocks/cta-banner.blade.php
+++ b/site/web/app/themes/sage/resources/views/blocks/cta-banner.blade.php
@@ -45,6 +45,9 @@
             $layout = 'default';
     }
 
+    if($image) {
+      $image_width = $image_width ?? '50'; // Default to 50% if not set
+    }
 @endphp
 <section
     class="cta-wrapper {{ !$image ? $layout : 'full-bleed' }} {{ $wrapper ? $wrapper : '' }} {{ $spacing_size ? $spacing_size : '' }} bg--{{ $background_colour }}">
@@ -75,7 +78,7 @@
 
 
     @if ($image)
-        <div class="cta-banner__image">
+        <div class="cta-banner__image width--{{$image_width}}">
             <img class="image--{{ $image_position }}" src="{{ $image['url'] }}""
                 alt="{{ $image['alt'] ? $image['alt'] : $image['name'] }}">
             <div

--- a/site/web/app/themes/sage/resources/views/blocks/cta-banner.blade.php
+++ b/site/web/app/themes/sage/resources/views/blocks/cta-banner.blade.php
@@ -4,6 +4,7 @@
         $btn_link = $cta_button['link'];
         $btn_text = $cta_button['text'];
         $btn_type = $cta_button['type'];
+        $btn_new_tab = $cta_button['new_tab'];
 
         if ($cta_button['btn_colour'] !== '') {
             $button_colour = $cta_button['btn_colour'];
@@ -93,6 +94,7 @@
                             'link' => $btn_link,
                             'text' => $btn_text,
                             'colour' => $button_colour,
+                            'new_tab' => $btn_new_tab
                         ])
                     @endif
                 </div>

--- a/site/web/app/themes/sage/resources/views/blocks/custom-grid.blade.php
+++ b/site/web/app/themes/sage/resources/views/blocks/custom-grid.blade.php
@@ -20,6 +20,7 @@
         $btn_link = $cta_button['link'];
         $btn_text = $cta_button['text'];
         $btn_type = $cta_button['type'];
+        $btn_new_tab = $cta_button['new_tab'];
 
         if ($cta_button['btn_colour'] !== '') {
             $button_colour = $cta_button['btn_colour'];
@@ -97,6 +98,7 @@
                             'link' => $btn_link,
                             'text' => $btn_text,
                             'colour' => $button_colour,
+                            'new_tab' => $btn_new_tab,
                         ])
                     @endif
                 </div>

--- a/site/web/app/themes/sage/resources/views/blocks/form.blade.php
+++ b/site/web/app/themes/sage/resources/views/blocks/form.blade.php
@@ -25,13 +25,18 @@
     }
 @endphp
 <section
-    class="form-block full-bleed {{ $wrapper ? $wrapper : '' }} {{ $spacing_size ? $spacing_size : '' }} bg--{{ $background_colour }}">
+    class="form-block full-bleed {{ $wrapper ? $wrapper : '' }} {{ $spacing_size ? $spacing_size : '' }} bg--{{ $background_colour }} {{$form_type === 'contact' ? 'contact' : ''}}">
+
+    @if ($form_type === 'contact')
+    <iframe src="https://us12.list-manage.com/contact-form?u=c8747c61e4e4ff0f9c320dddd&form_id=8adf8b3ddecee5d44756aa1ce3996287" width="100%" height="100%" frameborder="0" allowfullscreen></iframe>
+    @endif
+
     @if ($image)
         <div class="form-block__image">
             <img src="{{ $image['url'] }}"" alt="{{ $image['alt'] ? $image['alt'] : $image['name'] }}">
             <div class="form-block__content container {{ $wrapper ? $wrapper : '' }} block-padding">
                 <div class="form-block__content__body flow">
-                    
+
                         @if ($title_style['title'])
                             @include('partials.title', [$title_style])
                         @endif
@@ -46,7 +51,7 @@
                                 Other
                             @endif
                         </div>
-                   
+
                 </div>
             </div>
         </div>
@@ -58,7 +63,7 @@
                 alt="Play it forward logo">
                </div>
             <div class="form-block__content__body--alt flow">
-                
+
                     @if ($title_style['title'])
                         @include('partials.title', [$title_style])
                     @endif
@@ -75,7 +80,7 @@
                             @endif
                         @endif
                     </div>
-               
+
             </div>
         </div>
     @endif

--- a/site/web/app/themes/sage/resources/views/blocks/hero-front-page.blade.php
+++ b/site/web/app/themes/sage/resources/views/blocks/hero-front-page.blade.php
@@ -25,6 +25,7 @@
         $btn_text = $cta_button['text'] ?? null;
         $btn_colour = 'raspberry';
         $btn_type = $cta_button['type'] ?? null;
+        $btn_new_tab = $cta_button['new_tab'] ?? false;
     }
 @endphp
 <section
@@ -72,6 +73,7 @@
                         'link' => $btn_link,
                         'text' => $btn_text,
                         'colour' => 'yellow',
+                        'new_tab' => $btn_new_tab,
                     ])
                 @endif
             </div>

--- a/site/web/app/themes/sage/resources/views/partials/button.blade.php
+++ b/site/web/app/themes/sage/resources/views/partials/button.blade.php
@@ -1,5 +1,5 @@
 @php
-  $new_tab = $btn_new_tab ?? false;
+  $new_tab = $new_tab ?? false;
 @endphp
 @switch($type)
     @case('donate')

--- a/site/web/app/themes/sage/resources/views/partials/button.blade.php
+++ b/site/web/app/themes/sage/resources/views/partials/button.blade.php
@@ -1,3 +1,6 @@
+@php
+  $new_tab = $btn_new_tab ?? false;
+@endphp
 @switch($type)
     @case('donate')
         @php
@@ -35,5 +38,5 @@
     @break
 
     @default
-        <a class="button button--primary button--{{ $colour }}" href="{{ $link }}">{{ $text }}</a>
+        <a class="button button--primary button--{{ $colour }}" href="{{ $link }}" target={{$new_tab ? '_blank' : '_self'}}>{{ $text }}</a>
 @endswitch

--- a/site/web/app/themes/sage/resources/views/template-custom.blade.php
+++ b/site/web/app/themes/sage/resources/views/template-custom.blade.php
@@ -98,7 +98,8 @@ Template Name: Pattern Library
     'btn_type' => 'primary',
     'btn_colour' => 'raspberry',
     'btn_link' => '#',
-    'btn_text' => 'Raspberry button'
+    'btn_text' => 'Raspberry button',
+    'btn_new_tab' => false
   ])
   @include('blocks.button-block', [
     'block' => (object) ['classes' => 'block-padding--bottom'],
@@ -108,7 +109,8 @@ Template Name: Pattern Library
     'btn_type' => 'primary',
     'btn_colour' => 'black',
     'btn_link' => '#',
-    'btn_text' => 'black button'
+    'btn_text' => 'black button',
+    'btn_new_tab' => true
   ])
 @include('blocks.button-block', [
   'block' => (object) ['classes' => 'block-padding--bottom'],
@@ -118,7 +120,8 @@ Template Name: Pattern Library
   'btn_type' => 'donate',
   'btn_colour' => 'dark-green',
   'btn_link' => '#',
-  'btn_text' => 'Donate'
+  'btn_text' => 'Donate',
+  'btn_new_tab' => false
 ])
 
 <section class="flow block-padding--bottom">
@@ -160,7 +163,7 @@ Template Name: Pattern Library
     ],
     'hero_content' => '<p>Hero subtitle - Lorem ipsum dolor sit amet: consectetur sadipscing. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum.Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum. Lorem ipsum dolor sit amet consectetur adipisicing elit.</p><p>Quisquam, voluptatum. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum. Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>',
     'show_button' => 'yes',
-    'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' => 'primary', 'btn_colour' => '', 'new_tab' => '']
+    'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' => 'primary', 'btn_colour' => '', 'new_tab' => false]
   ])
 
 </section>
@@ -205,7 +208,7 @@ Template Name: Pattern Library
   'body' => 'Body text - Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dolor eius in explicabo!',
   'image' => [],
   'show_button' => 'yes',
-  'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' =>'primary', 'btn_colour' => '', 'new_tab' => '']
+  'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' =>'primary', 'btn_colour' => '', 'new_tab' => true]
 ])
 
 {{-- CTA - default --}}
@@ -220,7 +223,7 @@ Template Name: Pattern Library
   'image' => [],
   'image_position' => 'left',
   'show_button' => 'yes',
-  'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' => 'primary', 'btn_colour' => '', 'new_tab' => '']
+  'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' => 'primary', 'btn_colour' => '', 'new_tab' => true]
 ])
 
 {{-- CTA - full --}}
@@ -546,7 +549,8 @@ Template Name: Pattern Library
         'link' => '#',
         'text' => 'Button text',
         'type' => 'primary',
-        'btn_colour' => 'dark-green'
+        'btn_colour' => 'dark-green',
+        'new_tab' => false
       ],
       [
         'image' => ['sizes' => ['medium_large' => 'https://placehold.co/500x300'], 'alt' => 'alt text'],
@@ -554,7 +558,8 @@ Template Name: Pattern Library
         'link' => '#',
         'text' => 'Button text',
         'type' => 'primary',
-        'btn_colour' => 'black'
+        'btn_colour' => 'black',
+        'new_tab' => false
       ],
       [
         'image' => ['sizes' => ['medium_large' => 'https://placehold.co/500x300'], 'alt' => 'alt text'],
@@ -562,7 +567,8 @@ Template Name: Pattern Library
         'link' => '#',
         'text' => 'Button text',
         'type' => 'primary',
-        'btn_colour' => 'raspberry'
+        'btn_colour' => 'raspberry',
+        'new_tab' => true
       ],
     ]
   ])
@@ -674,11 +680,8 @@ Template Name: Pattern Library
         'description' => 'Description 4'
       ]
     ],
-    'show_button' => 'no',
-    'btn_type' => '',
-    'btn_link' => '',
-    'btn_text' => '',
-    'btn_colour' => ''
+    'show_button' => 'yes',
+    'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' => 'primary', 'btn_colour' => 'yellow', 'new_tab' => true]
   ])
 
   @include('blocks.custom-grid', [

--- a/site/web/app/themes/sage/resources/views/template-custom.blade.php
+++ b/site/web/app/themes/sage/resources/views/template-custom.blade.php
@@ -9,7 +9,7 @@ Template Name: Pattern Library
 
   $args = array(
     'post_type' => 'football_teams',
-    'posts_per_page' => 2, 
+    'posts_per_page' => 2,
   );
 
   $football_query = new WP_Query($args);
@@ -126,19 +126,19 @@ Template Name: Pattern Library
   <p>Added to the top of the front page. Consists of hero_image: An image field for uploading a hero image. The image can be of the types 'jpg', 'jpeg', 'png', or 'svg'.
 
     hero image position: A select field for choosing the position of the hero image. The choices are 'Center', 'Top', 'Bottom', 'Left', and 'Right', with 'Center' as the default value.
-  
+
     Hero Content: This is a tab for organizing the fields in the WordPress editor.
-  
+
     hero title: A text field for entering the hero title.
-  
+
     highlighted text: This is a repeater field that allows you to add multiple sets of sub-fields. Each set of sub-fields includes a text field for entering highlighted text.
-  
+
     impact text: This is another repeater field that allows you to add multiple sets of sub-fields. Each set of sub-fields includes a text field for entering impact text.
-  
+
     hero content: A WYSIWYG (What You See Is What You Get) editor field for entering the hero subtitle. Media upload is disabled.
-  
+
     show button: A radio button field for choosing whether to show a button. The choices are 'Yes' and 'No', with 'No' as the default value.
-  
+
     cta button: This is a group of fields for defining a call-to-action (CTA) button. It includes a set of fields defined in the Button class (shown if show_button is 'Yes').
   </p>
   <br>
@@ -160,9 +160,9 @@ Template Name: Pattern Library
     ],
     'hero_content' => '<p>Hero subtitle - Lorem ipsum dolor sit amet: consectetur sadipscing. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum.Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum. Lorem ipsum dolor sit amet consectetur adipisicing elit.</p><p>Quisquam, voluptatum. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, voluptatum. Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>',
     'show_button' => 'yes',
-    'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' => 'primary', 'btn_colour' => '']
+    'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' => 'primary', 'btn_colour' => '', 'new_tab' => '']
   ])
-  
+
 </section>
 
 <section class="flow block-padding--bottom">
@@ -205,7 +205,7 @@ Template Name: Pattern Library
   'body' => 'Body text - Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dolor eius in explicabo!',
   'image' => [],
   'show_button' => 'yes',
-  'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' =>'primary', 'btn_colour' => '']
+  'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' =>'primary', 'btn_colour' => '', 'new_tab' => '']
 ])
 
 {{-- CTA - default --}}
@@ -220,19 +220,19 @@ Template Name: Pattern Library
   'image' => [],
   'image_position' => 'left',
   'show_button' => 'yes',
-  'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' => 'primary', 'btn_colour' => '']
+  'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' => 'primary', 'btn_colour' => '', 'new_tab' => '']
 ])
 
 {{-- CTA - full --}}
 @include('blocks.cta-banner', [
-  'layout' => 'full', 
-  'background_colour' => 'raspberry', 
-  'wrapper' => '', 
-  'spacing_size' => '', 
+  'layout' => 'full',
+  'background_colour' => 'raspberry',
+  'wrapper' => '',
+  'spacing_size' => '',
   'title_style' => ['title' => 'CTA - variation full', 'heading_level' => 'h2', 'heading_style' => 'h2'],
-  'body' => 'Body text - Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dolor eius in explicabo!', 
+  'body' => 'Body text - Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dolor eius in explicabo!',
   'image' => ['url' => 'https://placehold.co/800x800', 'alt' => 'alt text'], 'image_position' => 'left','show_button' => 'yes',
-  'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' => 'primary', 'btn_colour' => '']
+  'cta_button' => ['link' => '#', 'text' => 'Button text', 'type' => 'primary', 'btn_colour' => '', 'new_tab' => '']
 ])
 </section>
 
@@ -466,7 +466,7 @@ Template Name: Pattern Library
   <p>Displays a grid of partner logos. Consists of Title: This is a set of fields defined in the Title class.
 
     body: A WYSIWYG (What You See Is What You Get) editor field for entering content. Media upload is disabled, and it uses the 'basic' toolbar.
-  
+
     partners: This is a repeater field that allows you to add multiple sets of sub-fields. Each set of sub-fields includes an image field for uploading a logo, a text field for entering a name, a textarea field for entering a description, and a URL field for entering a URL.</p>
   @include('blocks.partners', [
     'wrapper' => '',
@@ -543,25 +543,25 @@ Template Name: Pattern Library
       [
         'image' => ['sizes' => ['medium_large' => 'https://placehold.co/500x300'], 'alt' => 'alt text'],
         'title' => 'Card title',
-        'link' => '#', 
-        'text' => 'Button text', 
-        'type' => 'primary', 
+        'link' => '#',
+        'text' => 'Button text',
+        'type' => 'primary',
         'btn_colour' => 'dark-green'
       ],
       [
         'image' => ['sizes' => ['medium_large' => 'https://placehold.co/500x300'], 'alt' => 'alt text'],
         'title' => 'Card title 2',
-        'link' => '#', 
-        'text' => 'Button text', 
-        'type' => 'primary', 
+        'link' => '#',
+        'text' => 'Button text',
+        'type' => 'primary',
         'btn_colour' => 'black'
       ],
       [
         'image' => ['sizes' => ['medium_large' => 'https://placehold.co/500x300'], 'alt' => 'alt text'],
         'title' => 'Card title 3',
-        'link' => '#', 
-        'text' => 'Button text', 
-        'type' => 'primary', 
+        'link' => '#',
+        'text' => 'Button text',
+        'type' => 'primary',
         'btn_colour' => 'raspberry'
       ],
     ]
@@ -617,7 +617,7 @@ Template Name: Pattern Library
   <h2>Quote</h2>
   <p>Displays a quote. Consists of quote style: A radio button field for selecting the style of quote to use. The choices are 'Short' and 'Long'.
 
-    quote text: A textarea field for entering the quote text. 
+    quote text: A textarea field for entering the quote text.
 
     quote author: A text field for entering the quote author.</p>
   @include('blocks.quote', [
@@ -633,13 +633,13 @@ Template Name: Pattern Library
 
 <section class="flow block-padding--bottom">
   <h2>Custom Grid</h2>
-  <p>A simple Custom Grid block. Can be used to display a grid of items. 
+  <p>A simple Custom Grid block. Can be used to display a grid of items.
 
   Consists of grid type: A select field for choosing the type of grid to display. The choices are 'Icons' and 'Standard', with 'Standard' as the default value.
   Standard allows you to add a title, description and a grid of statistic items.
-  
+
   Icons allows you to add a title, description and a grid of icons.
-  
+
 
   title: This is a set of fields defined in the Title class.
 
@@ -823,9 +823,9 @@ Template Name: Pattern Library
   <p>Displays the latest results of 2 selected football teams. Consists of Team One and Team Two: These are tabs for organizing the fields in the WordPress editor. Each team has the following fields:
 
     team one and team two: A post object field for selecting a post of the 'football teams' post type. The selected post is returned as an object.
-  
+
     team one title and team two title: A text field for entering a title.
-  
+
     team one body and team two body: A WYSIWYG (What You See Is What You Get) editor field for entering sub text. Media upload is disabled, and it uses the 'basic' toolbar.</p>
     <br>
   @if ($football_query->have_posts() && $football_query->post_count > 1)
@@ -842,7 +842,7 @@ Template Name: Pattern Library
   @else
     <p>Not enough teams to display results. Add at least 2 teams under the football teams post type</p>
   @endif
-  
+
 </section>
 
 <section class="flow block-padding--bottom">


### PR DESCRIPTION
This is already possible. In the CTA banner block head to the 'Image' tab and then change the 'image position' field from right to left, vice versa. Missed this, thanks.
2. So, the way I built it was that the button colour would be hard coded based on the background colour, so you can't mix colours as Ellie said these were the correct contrasts. What colour combo is it your after? I now see what you mean, ignore me.
3. Afraid not. The screen has a content width, so all content is contained within it for consistency. Removing this would end up making the site really messy. Another option could be to reduce the width of the image, so instead of a 50/50 split its more 40/60 image text, giving text a bit more room. What you think?  This works - can it be an option to change 50/50 or 40/60 rather than always 40/60? No worries if not.        
4. Sure, this option won't be on every block, but most will have the option. Great thanks. For example, with the Victoria Falls Marathon when people click the link it leaves our website completely - would be much better to open a new tab in this case.
5. Can you link me to the page where this is happening? Will have a rethink. Pretty sure the code currently positions titles alternating top and bottom. If its easier we can just always have it at the bottom, that way it shouldn't cover faces as most will be toward the top of the image. Yeah generally faces are at the top so bottom titles are better - see attached for screenshot of this.
6. What page is this on? Think I already built something like this. On the home page - it displays 8 featured posts at the moment - I think probably 4 would look better here.


Reworked contact to use mailchimp form in an iframe