### PR TITLE
Amends/sep25

### DIFF
--- a/site/web/app/themes/sage/app/Blocks/ArchivePosts.php
+++ b/site/web/app/themes/sage/app/Blocks/ArchivePosts.php
@@ -128,7 +128,7 @@ class ArchivePosts extends Block
         'wrapper' => '',
         'spacing_size' => '',
         'title_style' => ['title' => 'Archive Posts Title', 'heading_level' => 'h2', 'heading_style' => 'h2'],
-        'latest_posts_type' => 'post',
+        'latest_posts_type' => 'news',
     ];
 
     /**
@@ -169,6 +169,10 @@ class ArchivePosts extends Block
                 'label' => 'Post Type',
                 'instructions' => 'Choose the post type to display.',
                 'default_value' => 'post',
+                'choices' => [
+                    'post' => 'Blog Posts',
+                    'news' => 'News Articles',
+                ],
             ]);
         return $archivePosts->build();
     }

--- a/site/web/app/themes/sage/app/setup.php
+++ b/site/web/app/themes/sage/app/setup.php
@@ -195,10 +195,10 @@ add_action('widgets_init', function () {
 });
 
 /**
- * Nav walker 
- * 
+ * Nav walker
+ *
  * If nav item is a # swap it to a span.
- * Add carets to nav items with child elements 
+ * Add carets to nav items with child elements
  */
 class AWP_Menu_Walker extends \Walker_Nav_Menu
 {
@@ -273,7 +273,7 @@ add_filter('acf/load_field/name=text_background_colour', function ($field) {
 
 /**
  * ACF WP User Select
- * 
+ *
  * Dynamically populates any ACF field with selected_user Field Name with wp users
  * Default value is the current user
  *
@@ -281,16 +281,16 @@ add_filter('acf/load_field/name=text_background_colour', function ($field) {
 add_filter('acf/load_field/name=selected_user', function ($field) {
     $users = get_users(['fields' => ['ID', 'display_name']]);
     $choices = [];
-    
+
     foreach ($users as $user) {
         $choices[$user->ID] = $user->display_name;
     }
 
-    $blog_user = get_user_by('ID', get_current_user_id()); 
-    $default_user_id = $blog_user ? $blog_user->ID : ''; 
+    $blog_user = get_user_by('ID', get_current_user_id());
+    $default_user_id = $blog_user ? $blog_user->ID : '';
 
     $field['choices'] = $choices;
-    $field['default_value'] = $default_user_id; 
+    $field['default_value'] = $default_user_id;
 
     return $field;
 });
@@ -312,9 +312,10 @@ add_action('rest_api_init', function () {
         'callback' => function ($request) {
             $page = $request->get_param('page');
             $per_page = $request->get_param('per_page');
+            $post_type = $request->get_param('post_type') ?: 'post'; // Default to 'post' if not specified
 
             $args = [
-                'post_type' => 'post',
+                'post_type' => $post_type,
                 'posts_per_page' => $per_page,
                 'paged' => $page,
                 'orderby' => 'date',
@@ -355,6 +356,36 @@ add_action('init', function () {
         'taxonomies' => ['category', 'post_tag'],
         'rewrite' => [
             'slug' => 'football-teams',
+            'with_front' => false,
+        ],
+    ]);
+});
+
+// register a custom post type called 'News'
+add_action('init', function () {
+    register_post_type('news', [
+        'labels' => [
+            'name' => __('News'),
+            'singular_name' => __('News Article'),
+            'add_new' => __('Add New News Article'),
+            'add_new_item' => __('Add New News Article'),
+            'edit_item' => __('Edit News Article'),
+            'new_item' => __('New News Article'),
+            'view_item' => __('View News Article'),
+            'search_items' => __('Search News'),
+            'not_found' => __('No news articles found'),
+            'not_found_in_trash' => __('No news articles found in trash'),
+            'all_items' => __('All News Articles'),
+            'archives' => __('News Archives'),
+        ],
+        'public' => true,
+        'has_archive' => true,
+        'menu_icon' => 'dashicons-megaphone',
+        'supports' => ['title', 'editor', 'thumbnail', 'excerpt', 'revisions', 'author'],
+        'show_in_rest' => true,
+        'taxonomies' => ['category', 'post_tag'],
+        'rewrite' => [
+            'slug' => 'news',
             'with_front' => false,
         ],
     ]);

--- a/site/web/app/themes/sage/app/setup.php
+++ b/site/web/app/themes/sage/app/setup.php
@@ -379,13 +379,13 @@ add_action('init', function () {
             'archives' => __('News Archives'),
         ],
         'public' => true,
-        'has_archive' => true,
+        'has_archive' => false,
         'menu_icon' => 'dashicons-megaphone',
         'supports' => ['title', 'editor', 'thumbnail', 'excerpt', 'revisions', 'author'],
         'show_in_rest' => true,
         'taxonomies' => ['category', 'post_tag'],
         'rewrite' => [
-            'slug' => 'news',
+            'slug' => 'news-article',
             'with_front' => false,
         ],
     ]);

--- a/site/web/app/themes/sage/resources/scripts/app.js
+++ b/site/web/app/themes/sage/resources/scripts/app.js
@@ -41,7 +41,9 @@ domReady(async () => {
       }, 500);
 
       const response = await fetch(
-        `/wp-json/v1/posts/load_more?page=${currentPage}&per_page=${num}`
+        `/wp-json/v1/posts/load_more?page=${currentPage}&per_page=${num}&post_type=${
+          loadMoreButton.getAttribute('data-post-type') || 'post'
+        }`
       );
       const newPosts = await response.json();
       // Check if there are new posts

--- a/site/web/app/themes/sage/resources/views/blocks/archive-posts.blade.php
+++ b/site/web/app/themes/sage/resources/views/blocks/archive-posts.blade.php
@@ -24,7 +24,7 @@
         <div class="spinner"><img src="{{ asset('images/football_loading.gif') }}" alt="loading image"></div>
         @if ($latest_posts->post_count >= 9)
             <div class="btn__wrapper">
-                <button class="button button--primary button--raspberry" id="load-more" data-num="9">Load more</button>
+                <button class="button button--primary button--raspberry" id="load-more" data-num="9" data-post-type="{{ $latest_posts_type }}">Load more</button>
             </div>
         @endif
     </div>


### PR DESCRIPTION
This pull request introduces support for a new custom post type called "News" alongside the existing "Blog Posts" in the archive and load more functionality. The changes ensure that users can select between blog posts and news articles, and that the backend and frontend handle this selection consistently.

**Custom Post Type Addition:**

* Registered a new custom post type `news` with appropriate labels, REST API support, and taxonomy associations.

**Archive and API Enhancements:**

* Updated the default value for `latest_posts_type` in the `ArchivePosts` block to `news` and added a field choice for "Blog Posts" and "News Articles" in the block settings. [[1]](diffhunk://#diff-82126b6c37699fbfa7f10924950c25695e8460aa4c7ef3b045bff7cef02ae1c2L131-R131) [[2]](diffhunk://#diff-82126b6c37699fbfa7f10924950c25695e8460aa4c7ef3b045bff7cef02ae1c2R172-R175)
* Modified the REST API endpoint to accept a `post_type` parameter, defaulting to `post` if not specified, allowing dynamic retrieval of either blog posts or news articles.

**Frontend Integration:**

* Passed the selected post type as a `data-post-type` attribute in the "Load more" button and ensured the frontend fetch request includes this parameter. [[1]](diffhunk://#diff-47f85017332ed8c3f2a4c1daf54f8f3cfe03accb9deeb8d518823dbd7771a32fL27-R27) [[2]](diffhunk://#diff-6e9d31824d8e0e4871db5cef2f7adeae452171ba22313beee368f1051614e253L44-R46)